### PR TITLE
Send whole comment to Matrix server on comment event.

### DIFF
--- a/gitlab-webhook.go
+++ b/gitlab-webhook.go
@@ -243,7 +243,7 @@ func handleCommentEvent(payload interface{}, room mautrix.Room) {
 	}
 
 	room.SendfHTML(
-		"[%[1]s/%[2]s] %[3]s <a href='%[5]s'>commented</a> on %[4]s %[6]s (%[8]c%[7]d)",
+		"[%[1]s/%[2]s] %[3]s <a href='%[5]s'>commented</a> on %[4]s %[6]s (%[8]c%[7]d): %[9]s",
 		data.Project.Namespace,
 		data.Project.Name,
 		data.User.Name,
@@ -251,7 +251,8 @@ func handleCommentEvent(payload interface{}, room mautrix.Room) {
 		data.ObjectAttributes.URL,
 		title,
 		id,
-		notebookIdentifier)
+		notebookIdentifier,
+		data.ObjectAttributes.Note)
 }
 
 func handlePipelineEvent(payload interface{}, room mautrix.Room) {


### PR DESCRIPTION
I am not sure if you might want to add this to upstream: This will add the text of issue comments to the chat.

I personally find it very useful to actually see the content of the comments in the chat, rather than only receiving a message that someone commented something and having to click in order to see what is going on.