### PR TITLE
gitlab_hook.py: fixed "past_tense" function

### DIFF
--- a/gitlab_matrix/gitlab_hook.py
+++ b/gitlab_matrix/gitlab_hook.py
@@ -537,7 +537,7 @@ class GitlabTagEvent(SerializableAttrs['GitlabTagEvent'], GitlabEvent):
 def past_tense(action: str) -> str:
     if not action:
         return action
-    elif action[-2:-1] != "ed":
+    elif action[-2:] != "ed":
         if action[-1] == "e":
             return f"{action}d"
         return f"{action}ed"


### PR DESCRIPTION
The `elif action[-2:-1] != "ed"` test is always true because the right test should use `action[-2:]` in the comparison.

This should fix #37.

Tested with:

- past_tense(None) => None
- past_tense('approve') => 'approved'
- past_tense('approved') => 'approved'
- past_tense('actione') => 'actioned'
