### PR TITLE
Update gitlab branch URL pattern

### DIFF
--- a/gitlab_matrix/types.py
+++ b/gitlab_matrix/types.py
@@ -676,7 +676,7 @@ class GitlabPushEvent(SerializableAttrs, GitlabEvent):
     @property
     def ref_url(self) -> Optional[str]:
         if self.ref.startswith("refs/heads/"):
-            return f"{self.project.web_url}/-/branches/{self.ref_name}"
+            return f"{self.project.web_url}/-/tree/{self.ref_name}"
         elif self.ref.startswith("refs/tags/"):
             return f"{self.project.web_url}/-/tags/{self.ref_name}"
         else:


### PR DESCRIPTION
Looks like they want "tree" instead of branches, ex: https://gitlab.com/gitlab-org/gitlab/-/tree/mark-banned-user-issues-hidden