### PR TITLE
Fix exception in whoami command

### DIFF
--- a/gitlab_matrix/commands/server.py
+++ b/gitlab_matrix/commands/server.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from gitlab import Gitlab as Gl, GitlabAuthenticationError
+from yarl import URL
 
 from maubot.handlers import command
 from maubot import MessageEvent


### PR DESCRIPTION
The `URL` import went missing in aa22103594 and thus an exception
is raised, when the `whoami` command is executed.