### PR TITLE
Allow hiding of event details

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -2,3 +2,4 @@ secret: "put a random password here"
 base_command: "gitlab"
 send_as_notice: true
 time_format: "%d.%m.%Y %H:%M:%S %Z"
+hide_details: false

--- a/gitlab_matrix/util/config.py
+++ b/gitlab_matrix/util/config.py
@@ -28,3 +28,4 @@ class Config(BaseProxyConfig):
         helper.copy("base_command")
         helper.copy("send_as_notice")
         helper.copy("time_format")
+        helper.copy("hide_details")

--- a/gitlab_matrix/webhook.py
+++ b/gitlab_matrix/webhook.py
@@ -153,6 +153,7 @@ class GitlabWebhook:
             **OTHER_ENUMS,
             "abort": abort,
             "util": TemplateUtil,
+            "hide_details": True,
         }
 
         for subevt in evt.preprocess():

--- a/templates/messages/comment.html
+++ b/templates/messages/comment.html
@@ -14,7 +14,9 @@
     {# unsupported comment target #}
     {% do abort() %}
 {% endif %}
-<br/>
-{% if object_attributes.description %}
-    <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+{% if not hide_details %}
+    <br/>
+    {% if object_attributes.description %}
+        <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+    {% endif %}
 {% endif %}

--- a/templates/messages/issue_open.html
+++ b/templates/messages/issue_open.html
@@ -1,6 +1,9 @@
 {{ templates.repo_sender_prefix }}
- opened {{ issue_link(object_attributes) }}<br/>
-{% if object_attributes.description %}
-    <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+ opened {{ issue_link(object_attributes) }}
+{% if not hide_details %}
+    <br/>
+    {% if object_attributes.description %}
+        <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+    {% endif %}
+    {{ fancy_labels(object_attributes.labels) }}
 {% endif %}
-{{ fancy_labels(object_attributes.labels) }}

--- a/templates/messages/merge_request.html
+++ b/templates/messages/merge_request.html
@@ -1,10 +1,12 @@
 {{ templates.repo_sender_prefix }}
 {% if action == OPEN %}
     opened {{ merge_request_link(object_attributes) }}
-    {% if object_attributes.description %}
-        <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+    {% if not hide_details %}
+        {% if object_attributes.description %}
+            <blockquote>{{ object_attributes.description|markdown }}</blockquote>
+        {% endif %}
+        {{ fancy_labels(labels) }}
     {% endif %}
-    {{ fancy_labels(labels) }}
 {% else %}
     {{ object_attributes.action.past_tense }}
     {{ merge_request_link(object_attributes) }}

--- a/templates/messages/tag.html
+++ b/templates/messages/tag.html
@@ -6,7 +6,7 @@
     created tag
     <a data-mautrix-exclude-plaintext href="{{ ref_url }}">{{ ref_name }}</a>
 {% endif %}
-{%- if message -%}:
+{%- if message and not hide_details -%}:
     <blockquote>
         {{ message | markdown }}
     </blockquote>


### PR DESCRIPTION
The optional configuration setting "hide_details" can be used for
omitting event details in matrix messages triggered via webhooks.