### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Where
 
 Which gives for example, with the default configuration: <https://maubot.example.org/_matrix/maubot/plugin/my_gitlab_bot/webhooks?room=!XXXXXXXXXXXX>.
 
-Then configure the `secret` token as previously defined.
+As `secret`, set the token shown in Maubot's **Instances** > **my_gitlab_bot** > **secret:**
 
 Afterwhile, configure the desired permissions, [enable SSL verification if needed](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#ssl-verification) and create the webhook.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Go to the desired repository's webhooks settings, in Gitlab, under **Your repo**
 Configure the **URL** as follows:
 
 ```sh
-https://${server_name}/${plugin_base_path}/${instance_id}/${instance_path}?room=${room_id}
+https://${server_name}/${plugin_base_path}/${instance_id}/webhooks?room=${room_id}
 ```
 
 Where
@@ -59,7 +59,6 @@ Where
 - `${server_name}` is an ip address or domain name where your Maubot instance is reachable
 - `${base_path}` is the base path for plugin endpoint as configured under `server.plugin_base_path` in `config.yaml`
 - `${instance_id}` is the identifier you previously defined while setting up the plugin instance, here `my_gitlab_bot`
-- `${instance_path}` is the `path` defined in **Maubot Manager** > **Instances** > `my_gitlab_bot` > `path`
 - `${room_id}` is the Matrix room identifier as defined in its URL, or under **Room Settings** > **Advanced** > **Internal room identifier**
 
 Which gives for example, with the default configuration: <https://maubot.example.org/_matrix/maubot/plugin/my_gitlab_bot/webhooks?room=!XXXXXXXXXXXX>.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Where
 - `${server_name}` is an ip address or domain name where your Maubot instance is reachable
 - `${base_path}` is the base path for plugin endpoint as configured under `server.plugin_base_path` in `config.yaml`
 - `${instance_id}` is the identifier you previously defined while setting up the plugin instance, here `my_gitlab_bot`
-- `${room_id}` is the Matrix room identifier as defined in its URL, or under **Room Settings** > **Advanced** > **Internal room identifier**
+- `${room_id}` is the Matrix room identifier as defined in its URL (or, if you're using the Element client) under **Room Settings** > **Advanced** > **Internal room identifier**. Make sure to use a room where the Gitlab bot is invited, otherwise the webhook will fail with an HTTP 403 error.
 
 Which gives for example, with the default configuration: <https://maubot.example.org/_matrix/maubot/plugin/my_gitlab_bot/webhooks?room=!XXXXXXXXXXXX>.
 


### PR DESCRIPTION
A few updates because the readme does not look up-to-date anymore.

Also, I'm not totally sure about my second commit. I first configured a random `secret`, and maubot would reply HTTP 401 (Unauthorized) to `/_matrix/maubot/plugin/gitlab/webhooks`.

After I understood where to get the secret, Maubot now replies a 403 (Forbidden). I think that's slightly better, but this still does not work. Am I doing something wrong? (I'm still trying to get the Gitlab bot up and running, but that still isn't working for me).

By the way, I am trying the manual setup of webhooks because the automated `!gitlab webhook add https://gitlab.corp.com group/project` failed with the following error. Should I open a new issue?

```
[2021-12-20 17:26:36,618] [ERROR@maubot.instance.gitlab] Failed to handle command
Traceback (most recent call last):
  File "/data/plugins/xyz.maubot.gitlab-v0.2.0.mbp/gitlab_matrix/util/decorators.py", line 50, in wrapper
    return await func(self, evt, gl=gl, **kwargs)
  File "/data/plugins/xyz.maubot.gitlab-v0.2.0.mbp/gitlab_matrix/commands/webhook.py", line 38, in webhook_add
    project = gl.projects.get(repo)
  File "/usr/lib/python3.9/site-packages/gitlab/v4/objects/projects.py", line 782, in get
    return cast(Project, super().get(id=id, lazy=lazy, **kwargs))
  File "/usr/lib/python3.9/site-packages/gitlab/exceptions.py", line 304, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/gitlab/mixins.py", line 115, in get
    return self._obj_cls(self, server_data)
  File "/usr/lib/python3.9/site-packages/gitlab/base.py", line 56, in __init__
    raise GitlabParsingError(
gitlab.exceptions.GitlabParsingError: Attempted to initialize RESTObject with a non-dictionary value: [{'id': 114, 'description': " .....REDACTED..... {'access_level': 50, 'notification_level': 3}}}]
This likely indicates an incorrect or malformed server response.
[2021-12-20 17:27:04,543] [ERROR@maubot.client.@gitlab_bot:hlab.ems.host] Failed to run handler
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/mautrix/client/syncer.py", line 204, in _catch_errors
    await handler(data)
  File "/opt/maubot/maubot/handlers/command.py", line 108, in __call__
    ok, res = await self.__call_subcommand__(evt, call_args, remaining_val)
  File "/opt/maubot/maubot/handlers/command.py", line 128, in __call_subcommand__
    return True, await subcommand(evt, _existing_args=call_args,
  File "/opt/maubot/maubot/handlers/command.py", line 108, in __call__
    ok, res = await self.__call_subcommand__(evt, call_args, remaining_val)
  File "/opt/maubot/maubot/handlers/command.py", line 128, in __call_subcommand__
    return True, await subcommand(evt, _existing_args=call_args,
  File "/opt/maubot/maubot/handlers/command.py", line 104, in __call__
    ok, remaining_val = await self.__parse_args__(evt, call_args, remaining_val)
  File "/opt/maubot/maubot/handlers/command.py", line 136, in __parse_args__
    remaining_val, call_args[arg.name] = arg.match(remaining_val.strip(), evt=evt,
  File "/data/plugins/xyz.maubot.gitlab-v0.2.0.mbp/gitlab_matrix/util/arguments.py", line 40, in match
    return " ".join(vals[1:]), instance.bot.db.get_login(evt.sender, url_alias=val[0])
  File "/data/plugins/xyz.maubot.gitlab-v0.2.0.mbp/gitlab_matrix/db.py", line 154, in get_login
    row = (s.query(Token)
  File "/usr/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 3500, in one
    raise orm_exc.NoResultFound("No row was found for one()")
sqlalchemy.orm.exc.NoResultFound: No row was found for one()
```