### PR TITLE
Add support for reviewer changes in merge requests

### DIFF
--- a/gitlab_matrix/types.py
+++ b/gitlab_matrix/types.py
@@ -253,6 +253,12 @@ class GitlabAssigneeChanges(GitlabChangeWrapper, SerializableAttrs):
 
 
 @dataclass
+class GitlabReviewersChanges(GitlabChangeWrapper, SerializableAttrs):
+    previous: List[GitlabUser]
+    current: List[GitlabUser]
+
+
+@dataclass
 class GitlabLabelChanges(GitlabChangeWrapper, SerializableAttrs):
     previous: List[GitlabLabel]
     current: List[GitlabLabel]
@@ -290,6 +296,7 @@ class GitlabChanges(SerializableAttrs):
     title: Optional[GitlabStringChange] = None
     labels: Optional[GitlabLabelChanges] = None
     assignees: Optional[GitlabAssigneeChanges] = None
+    reviewers: Optional[GitlabReviewersChanges] = None
     time_estimate: Optional[GitlabIntChange] = None
     total_time_spent: Optional[GitlabIntChange] = None
     weight: Optional[GitlabIntChange] = None

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -73,3 +73,6 @@
 {%- macro assignee_changes(added, removed) -%}
     {{ list_changes(added, removed, "assigned", "unassigned", user_link) }}
 {%- endmacro -%}
+{%- macro reviewers_changes(added, removed) -%}
+    {{ list_changes(added, removed, "assigned", "unassigned", user_link) }}
+{%- endmacro -%}

--- a/templates/messages/issue_update.html
+++ b/templates/messages/issue_update.html
@@ -12,6 +12,9 @@
 {% elif changes.assignees %}
     {{ assignee_changes(changes.assignees.added, changes.assignees.removed) }}
     {{ issue_or_merge_link(object_attributes) }}
+{% elif changes.reviewers %}
+    {{ reviewers_changes(changes.reviewers.added, changes.reviewers.removed) }}
+    {{ issue_or_merge_link(object_attributes) }}
 {% elif changes.time_estimate %}
     {% if not changes.time_estimate.current %}
         removed the time estimate of {{ issue_or_merge_link(object_attributes) }}


### PR DESCRIPTION
The merge request event webhook is called for reviwers updates, however this is ignored by the GitlabChanges class. Therefore these updates are not forwarded to Matrix. By adding the reviewers section to both the GitlabChanges and to the issue_update template (which is used for merge request updates) the bot reports about changes in reviewers.