### PR TITLE
Add lock_on_merge property to GitlabLabel

### DIFF
--- a/gitlab_matrix/types.py
+++ b/gitlab_matrix/types.py
@@ -89,6 +89,7 @@ class GitlabLabel(SerializableAttrs):
     description: str
     type: LabelType
     group_id: Optional[int]
+    lock_on_merge: Optional[bool]
     remove_on_close: bool = False
 
     @property


### PR DESCRIPTION
This is a new column added to labels and it was preventing the bot to parse issue events.

More info on https://gitlab.com/gitlab-org/gitlab/-/merge_requests/127683

Closes https://github.com/maubot/gitlab/issues/67