### PR TITLE
Tolerate label attribute `lock_on_merge`

### DIFF
--- a/gitlab_matrix/types.py
+++ b/gitlab_matrix/types.py
@@ -90,6 +90,7 @@ class GitlabLabel(SerializableAttrs):
     type: LabelType
     group_id: Optional[int]
     remove_on_close: bool = False
+    lock_on_merge: bool = False
 
     @property
     def foreground_color(self) -> str:


### PR DESCRIPTION
In GitLab v16.3 the new label `lock_on_merge` was introduced (behind a feature flag).

We should tolerate this flag, if it appears in a webhook payload. Previously the deserialization of the webhook payload failed.