### PR TITLE
Notify only on failure

### DIFF
--- a/gitlab_matrix/bot.py
+++ b/gitlab_matrix/bot.py
@@ -17,23 +17,25 @@
 from typing import Type
 
 from mautrix.util.config import BaseProxyConfig
+from mautrix.util.async_db import UpgradeTable
 from maubot import Plugin
 
-from .db import Database
+from .db import DBManager
 from .util import Config
 from .webhook import GitlabWebhook
 from .commands import GitlabCommands
+from .migrations import upgrade_table
 
 
 class GitlabBot(Plugin):
-    db: Database
+    db: DBManager
     webhook: GitlabWebhook
     commands: GitlabCommands
 
     async def start(self) -> None:
         self.config.load_and_update()
 
-        self.db = Database(self.database)
+        self.db = DBManager(self.database)
         self.webhook = await GitlabWebhook(self).start()
         self.commands = GitlabCommands(self)
 
@@ -46,3 +48,7 @@ class GitlabBot(Plugin):
     @classmethod
     def get_config_class(cls) -> Type[BaseProxyConfig]:
         return Config
+
+    @classmethod
+    def get_db_upgrade_table(cls) -> UpgradeTable:
+        return upgrade_table

--- a/gitlab_matrix/commands/alias.py
+++ b/gitlab_matrix/commands/alias.py
@@ -29,18 +29,20 @@ class CommandAlias(Command):
     @command.argument("url", "server URL")
     @command.argument("alias", "server alias")
     async def alias_add(self, evt: MessageEvent, url: str, alias: str) -> None:
-        if url not in self.bot.db.get_servers(evt.sender):
+        servers = await self.bot.db.get_servers(evt.sender)
+        if url not in servers:
             await evt.reply("You can't add an alias to a GitLab server you are not logged in to.")
             return
-        if self.bot.db.has_alias(evt.sender, alias):
+        has_alias = await self.bot.db.has_alias(evt.sender, alias)
+        if has_alias:
             await evt.reply("Alias already in use.")
             return
-        self.bot.db.add_alias(evt.sender, url, alias)
+        await self.bot.db.add_alias(evt.sender, url, alias)
         await evt.reply(f"Added alias {alias} to server {url}")
 
     @alias.subcommand("list", aliases=("l", "ls"), help="Show your Gitlab server aliases.")
     async def alias_list(self, evt: MessageEvent) -> None:
-        aliases = self.bot.db.get_aliases(evt.sender)
+        aliases = await self.bot.db.get_aliases(evt.sender)
         if not aliases:
             await evt.reply("You don't have any aliases.")
             return
@@ -52,5 +54,5 @@ class CommandAlias(Command):
                       help="Remove a alias to a Gitlab server.")
     @command.argument("alias", "server alias")
     async def alias_rm(self, evt: MessageEvent, alias: str) -> None:
-        self.bot.db.rm_alias(evt.sender, alias)
+        await self.bot.db.rm_alias(evt.sender, alias)
         await evt.reply(f"Removed alias {alias}.")

--- a/gitlab_matrix/commands/room.py
+++ b/gitlab_matrix/commands/room.py
@@ -48,5 +48,5 @@ class CommandRoom(Command):
                 await evt.reply(f"Couldn't find {repo} on {gl.url}")
                 return
             raise
-        self.bot.db.set_default_repo(evt.room_id, gl.url, repo)
+        await self.bot.db.set_default_repo(evt.room_id, gl.url, repo)
         await evt.reply(f"Changed the default repo to {repo} on {gl.url}")

--- a/gitlab_matrix/commands/server.py
+++ b/gitlab_matrix/commands/server.py
@@ -32,12 +32,12 @@ class CommandServer(Command):
     @server.subcommand("default", aliases=("d",), help="Change your default GitLab server.")
     @command.argument("url", "server URL")
     async def server_default(self, evt: MessageEvent, url: str) -> None:
-        self.bot.db.change_default(evt.sender, url)
+        await self.bot.db.change_default(evt.sender, url)
         await evt.reply(f"Changed the default server to {url}")
 
     @server.subcommand("list", aliases=("ls",), help="Show your GitLab servers.")
     async def server_list(self, evt: MessageEvent) -> None:
-        servers = self.bot.db.get_servers(evt.sender)
+        servers = await self.bot.db.get_servers(evt.sender)
         if not servers:
             await evt.reply("You are not logged in to any server.")
             return
@@ -60,13 +60,13 @@ class CommandServer(Command):
                              exc_info=True)
             await evt.reply(f"GitLab login failed: {e}")
             return
-        self.bot.db.add_login(evt.sender, url, token)
+        await self.bot.db.add_login(evt.sender, url, token)
         await evt.reply(f"Successfully logged into GitLab at {url} as {gl.user.name}")
 
     @server.subcommand("logout", help="Remove the access token from the bot's database.")
     @command.argument("url", "server URL")
     async def server_logout(self, evt: MessageEvent, url: str) -> None:
-        self.bot.db.rm_login(evt.sender, url)
+        await self.bot.db.rm_login(evt.sender, url)
         await evt.reply(f"Removed {url} from the database.")
 
     @Command.gitlab.subcommand("ping", aliases=("p",), help="Ping the bot.")

--- a/gitlab_matrix/commands/webhook.py
+++ b/gitlab_matrix/commands/webhook.py
@@ -34,7 +34,7 @@ class CommandWebhook(Command):
     @with_gitlab_session
     async def webhook_add(self, evt: MessageEvent, repo: str, gl: Gl) -> None:
         token = secrets.token_urlsafe(64)
-        self.bot.db.add_webhook_room(token, evt.room_id)
+        await self.bot.db.add_webhook_room(token, evt.room_id)
         project = gl.projects.get(repo)
         hook = project.hooks.create({
             "url": f"{self.bot.webapp_url}/webhooks",

--- a/gitlab_matrix/migrations.py
+++ b/gitlab_matrix/migrations.py
@@ -1,0 +1,61 @@
+from mautrix.util.async_db import Connection, UpgradeTable
+
+upgrade_table = UpgradeTable()
+
+
+@upgrade_table.register(description="Initial revision")
+async def upgrade_v1(conn: Connection) -> None:
+    await conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS token (
+            user_id            VARCHAR(255),
+            gitlab_server      TEXT,
+            api_token          TEXT NOT NULL,
+
+            PRIMARY KEY (user_id, gitlab_server)
+        )"""
+    )
+    await conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS alias (
+            user_id            VARCHAR(255),
+            gitlab_server      TEXT,
+            alias              TEXT,
+
+            PRIMARY KEY (user_id, gitlab_server, alias),
+            FOREIGN KEY (user_id, gitlab_server) REFERENCES token (user_id, gitlab_server) ON DELETE CASCADE
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS "default" (
+            user_id            VARCHAR(255),
+            gitlab_server      TEXT NOT NULL,
+
+            PRIMARY KEY (user_id),
+            FOREIGN KEY (user_id, gitlab_server) REFERENCES token (user_id, gitlab_server) ON DELETE CASCADE
+        )"""
+    ) # add gitlab in primary key ?
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS default_repo (
+            room_id            VARCHAR(255),
+            server             VARCHAR(255) NOT NULL,
+            repo               VARCHAR(255) NOT NULL,
+
+            PRIMARY KEY (room_id)
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS matrix_message (
+            message_id             VARCHAR(255),
+            room_id                VARCHAR(255),
+            event_id               VARCHAR(255) NOT NULL,
+
+            PRIMARY KEY (message_id, room_id)
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS webhook_token (
+            room_id                TEXT NOT NULL,
+            secret                 TEXT,
+
+            PRIMARY KEY (secret)
+        )"""
+    )

--- a/gitlab_matrix/util/config.py
+++ b/gitlab_matrix/util/config.py
@@ -15,11 +15,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import secrets
+import os
+from typing import Any
 
 from mautrix.util.config import BaseProxyConfig, ConfigUpdateHelper
 
 
 class Config(BaseProxyConfig):
+    def __getitem__(self, key: str) -> Any:
+        try:
+            return os.environ[f"MAUBOT_GITLAB_{key.replace('.', '_').upper()}"]
+        except KeyError:
+            return super().__getitem__(key)
+
     def do_update(self, helper: ConfigUpdateHelper) -> None:
         if not self["secret"] or self["secret"] == "put a random password here":
             helper.base["secret"] = secrets.token_urlsafe(32)
@@ -28,3 +36,4 @@ class Config(BaseProxyConfig):
         helper.copy("base_command")
         helper.copy("send_as_notice")
         helper.copy("time_format")
+        helper.copy("notify_only_on_failure")

--- a/gitlab_matrix/util/decorators.py
+++ b/gitlab_matrix/util/decorators.py
@@ -37,10 +37,11 @@ def with_gitlab_session(func: Decoratable) -> Decorator:
         try:
             repo: Any = kwargs["repo"]
             if isinstance(repo, DefaultRepoInfo):
-                if repo.server not in self.bot.db.get_servers(evt.sender):
+                servers = await self.bot.db.get_servers(evt.sender)
+                if repo.server not in servers:
                     await evt.reply(f"You're not logged into {repo.server}")
                     return
-                login = self.bot.db.get_login(evt.sender, url_alias=repo.server)
+                login = await self.bot.db.get_login(evt.sender, url_alias=repo.server)
                 kwargs["repo"] = repo.repo
         except KeyError:
             pass

--- a/gitlab_matrix/webhook.py
+++ b/gitlab_matrix/webhook.py
@@ -29,7 +29,7 @@ from mautrix.types import (EventType, RoomID, StateEvent, Membership, MessageTyp
 from mautrix.util.formatter import parse_html
 from maubot.handlers import web, event
 
-from .types import GitlabJobEvent, EventParse, Action, OTHER_ENUMS
+from .types import GitlabJobEvent, EventParse, Action, BuildStatus, OTHER_ENUMS
 from .util import TemplateManager, TemplateUtil
 
 if TYPE_CHECKING:
@@ -131,6 +131,9 @@ class GitlabWebhook:
 
         was_manually_handled = True
         if isinstance(evt, GitlabJobEvent):
+            if self.bot.config["notify_only_on_failure"] and evt.build_status != BuildStatus.FAILED:
+                return
+
             await self.handle_job_event(evt, evt_type, room_id)
         else:
             was_manually_handled = False

--- a/gitlab_matrix/webhook.py
+++ b/gitlab_matrix/webhook.py
@@ -77,7 +77,7 @@ class GitlabWebhook:
                                      "Did you forget the ?room query parameter?\n",
                                 status=400)
         else:
-            room_id = self.bot.db.get_webhook_room(token)
+            room_id = await self.bot.db.get_webhook_room(token)
             if not room_id:
                 return Response(text="401: Unauthorized\n", status=401)
 
@@ -177,15 +177,16 @@ class GitlabWebhook:
             }
             content["com.beeper.linkpreviews"] = []
 
-            edit_evt = self.bot.db.get_event(subevt.message_id, room_id)
+            edit_evt = await self.bot.db.get_event(subevt.message_id, room_id)
             if edit_evt:
                 content.set_edit(edit_evt)
-            event_id = await self.bot.client.send_message(room_id, content)
-            if not edit_evt and subevt.message_id:
-                self.bot.db.put_event(subevt.message_id, room_id, event_id)
+            event_id = await self.bot.client.send_message(room_id, content, retry_count=5)
+
+            if not edit_evt and subevt.message_id and event_id:
+                await self.bot.db.put_event(subevt.message_id, room_id, event_id)
 
     async def handle_job_event(self, evt: GitlabJobEvent, evt_type: str, room_id: RoomID) -> None:
-        push_evt = self.bot.db.get_event(evt.push_id, room_id)
+        push_evt = await self.bot.db.get_event(evt.push_id, room_id)
         if not push_evt:
             self.bot.log.debug(f"No message found to react to push {evt.push_id}")
             return
@@ -201,11 +202,13 @@ class GitlabWebhook:
             **evt.meta,
         }
 
-        prev_reaction = self.bot.db.get_event(evt.reaction_id, room_id)
+        prev_reaction = await self.bot.db.get_event(evt.reaction_id, room_id)
         if prev_reaction:
-            await self.bot.client.redact(room_id, prev_reaction)
-        event_id = await self.bot.client.send_message_event(room_id, EventType.REACTION, reaction)
-        self.bot.db.put_event(evt.reaction_id, room_id, event_id, merge=prev_reaction is not None)
+            await self.bot.client.redact(room_id, prev_reaction, retry_count=5)
+
+        event_id = await self.bot.client.send_message_event(room_id, EventType.REACTION, reaction, retry_count=5)
+        if event_id:
+            await self.bot.db.put_event(evt.reaction_id, room_id, event_id)
 
     @event.on(EventType.ROOM_MEMBER)
     async def member_handler(self, evt: StateEvent) -> None:

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -18,4 +18,5 @@ soft_dependencies:
 
 webapp: true
 database: true
+database_type: asyncpg
 config: true


### PR DESCRIPTION
Hi,

We've been using your bot and we noticed that there were a lot of 429 errors in our logs.

It makes atleast 3 requests per job:

1 request to add a reaction to the push message to says that the job is creating
1 request to redact that redaction when a new state comes in
1 request to notify of the new state finished or failed

It can grows quite quickly, we have a pipeline with 15 jobs so maubot couldn't catch on, even with a retry the situation isn't ideal.

So with this PR I propose an option to only react to a message only when the job fails